### PR TITLE
Fix metrics on item update

### DIFF
--- a/src/application/service/item_service.rs
+++ b/src/application/service/item_service.rs
@@ -56,7 +56,13 @@ impl ItemService {
             if let Some(description) = req.description {
                 item.description = Some(description);
             }
-            self.repository.update(item).await
+            let updated = self.repository.update(item).await;
+            if updated.is_some() {
+                increment_success_counter("item", "update");
+            } else {
+                increment_error_counter("item", "update");
+            }
+            updated
         } else {
             increment_error_counter("item", "update");
             None


### PR DESCRIPTION
## Summary
- fix ItemService update metrics to track success/failure

## Testing
- `cargo clippy --all-targets -- -D warnings` *(fails: `cargo-clippy` not installed)*
- `cargo fmt -- src/application/service/item_service.rs` *(fails: `cargo-fmt` not installed)*
- `cargo test` *(fails to fetch dependencies: could not connect to crates.io)*
