### PR TITLE
Add contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing Guide
+
+このドキュメントでは、新規参加者が知っておくべきプロジェクトの概要と基本的な作業手順をまとめています。
+
+## リポジトリ構造
+
+主要なディレクトリと役割は以下のとおりです。
+
+```
+├── src/                # メインアプリケーション
+│   ├── main.rs         # エントリポイント
+│   ├── application/    # アプリケーション層（DTO、サービス）
+│   ├── domain/         # ドメイン層（モデル、リポジトリインターフェース）
+│   ├── infrastructure/ # インフラ層（DB、認証、ロギング）
+│   └── presentation/   # プレゼンテーション層（API ハンドラ）
+├── crates/domain/      # ドメイン層サブクレート
+├── k8s/                # Kubernetes マニフェスト
+├── initdb/             # DB 初期化 SQL
+├── scripts/            # 補助スクリプト
+├── o11y.md             # 可観測性ガイド
+├── Dockerfile          # コンテナイメージ定義
+├── docker-compose.yml  # ローカル開発環境
+```
+
+詳細な責務は `.github/directorystructure.md` を参照してください。
+
+## 開発環境のセットアップ
+
+1. Rust 1.77 以上、Docker と docker-compose をインストールしてください。
+2. `.env` ファイルを作成し、`DATABASE_URL` などの環境変数を設定します。
+3. 以下のコマンドでコンテナを起動します。
+
+```bash
+docker-compose up -d
+```
+
+ローカル実行だけなら `cargo run` でも起動できます。
+
+## 主要な開発コマンド
+
+```bash
+# テスト実行
+cargo test
+
+# フォーマット & Lint
+cargo fmt
+cargo clippy --all-targets -- -D warnings
+```
+
+可観測性の仕組みやトレース設定の詳細は `o11y.md` を参照してください。
+
+## コーディング規約
+
+- `unwrap()` や `expect()` は避け、適切に `Result` / `Option` を扱います。
+- すべての I/O 処理は `async/await` で記述します。
+- 4 スペースインデント、snake_case を使用します。
+
+## さらに学ぶべきこと
+
+- 認証機構：`src/infrastructure/auth/` の実装を確認してください。
+- テスト：`tests/` ディレクトリには統合テストの例があります。
+- Kubernetes デプロイ：`k8s/README.md` に本番環境向けの手順があります。
+
+以上を一通り把握すると、プロジェクトの全体像が掴みやすくなります。Issue や Pull Request は歓迎です。

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ cargo clippy --all-targets -- -D warnings
 詳細なデプロイ手順は [k8s/README.md](k8s/README.md) を参照してください。
 
 ## コントリビューション
-Issue や Pull Request は歓迎です。CONTRIBUTING.md は現在作成中ですが、以下の点にご協力ください：
+Issue や Pull Request は歓迎です。詳細な手順は [CONTRIBUTING.md](CONTRIBUTING.md) を参照してください。以下の点にご協力ください：
 
 - コードスタイルは `rustfmt` と `clippy` に準拠
 - 新機能には単体テストを追加


### PR DESCRIPTION
## Summary
- add `CONTRIBUTING.md` with instructions for new contributors
- link to new guide from README

## Testing
- `cargo fmt -- --check` *(fails: component rustfmt not installed)*
- `cargo clippy --all-targets -- -D warnings` *(fails: component clippy not installed)*
- `cargo test` *(fails to download crates: Could not connect to server)*