### PR TITLE
Fix warnings in tests

### DIFF
--- a/src/infrastructure/repository/item_repository.rs
+++ b/src/infrastructure/repository/item_repository.rs
@@ -63,6 +63,7 @@ impl PostgresItemRepository {
 
     // テーブルを初期化するメソッド（テスト用）
     #[cfg(any(test, feature = "testing"))]
+    #[allow(dead_code)]
     pub async fn init_table(&self) -> Result<(), sqlx::Error> {
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS items (

--- a/src/infrastructure/repository/user_repository.rs
+++ b/src/infrastructure/repository/user_repository.rs
@@ -63,6 +63,7 @@ impl PostgresUserRepository {
     
     // テスト用にテーブルを初期化するメソッド
     #[cfg(any(test, feature = "testing"))]
+    #[allow(dead_code)]
     pub async fn init_table(&self) -> Result<(), sqlx::Error> {
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS users (

--- a/tests/app_domain_repository_tests.rs
+++ b/tests/app_domain_repository_tests.rs
@@ -83,7 +83,6 @@ async fn test_mock_item_repository_create() {
         description: Some("New Description".to_string()),
     };
     
-    let expected_item = input_item.clone();
     
     mock_repo
         .expect_create()


### PR DESCRIPTION
## Summary
- remove an unused variable in `tests/app_domain_repository_tests.rs`
- silence `init_table` warnings in repository code with `#[allow(dead_code)]`

## Testing
- `cargo test --all --quiet`