### PR TITLE
テストヘルパーにおいて、未使用のコードを許可するために`#![allow(dead_code)]`を追加しました。これにより、テスト環境の…

### DIFF
--- a/tests/helpers/postgres.rs
+++ b/tests/helpers/postgres.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use sqlx::{postgres::PgPoolOptions, Pool, Postgres};
 use std::{sync::Once, time::Duration};
 use testcontainers_modules::postgres;

--- a/tests/helpers/test_environment.rs
+++ b/tests/helpers/test_environment.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use sqlx::{Pool, Postgres};
 use std::sync::Arc;
 use rust_webapi::app_domain::repository::item_repository::ItemRepository;


### PR DESCRIPTION
…設定が改善され、将来的な拡張が容易になります。